### PR TITLE
Add getters for filename, default block size, and override block size members

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
@@ -25,6 +25,8 @@
  */
 package org.janelia.saalfeldlab.n5.hdf5;
 
+import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -44,7 +46,6 @@ import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.RawCompression;
 import org.janelia.saalfeldlab.n5.ShortArrayDataBlock;
 import org.scijava.util.VersionUtils;
-
 import ch.systemsx.cisd.base.mdarray.MDByteArray;
 import ch.systemsx.cisd.base.mdarray.MDDoubleArray;
 import ch.systemsx.cisd.base.mdarray.MDFloatArray;
@@ -60,8 +61,9 @@ import ch.systemsx.cisd.hdf5.IHDF5Reader;
  * Best effort {@link N5Reader} implementation for HDF5 files.
  *
  * @author Stephan Saalfeld
+ * @author Philipp Hanslovsky
  */
-public class N5HDF5Reader implements N5Reader {
+public class N5HDF5Reader implements N5Reader, Closeable {
 
 	/**
 	 * SemVer version of this N5-HDF5 spec.
@@ -497,8 +499,33 @@ public class N5HDF5Reader implements N5Reader {
 		return attributes;
 	}
 
+	@Override
 	public void close() {
 
 		reader.close();
+	}
+
+	/**
+	 *
+	 * @return file name of HDF5 file this reader is associated with
+	 */
+	public File getFilename() {
+		return this.reader.file().getFile();
+	}
+
+	/**
+	 *
+	 * @return a copy of the default block size of this reader
+	 */
+	public int[] getDefaultBlockSizeCopy() {
+		return defaultBlockSize.clone();
+	}
+
+	/**
+	 *
+	 * @return {@code true} if this reader overrides block size found in an HDF5 dataset, {@code false} otherwise
+	 */
+	public boolean doesOverrideBlockSize() {
+		return this.overrideBlockSize;
 	}
 }

--- a/src/test/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Test.java
@@ -18,6 +18,7 @@ package org.janelia.saalfeldlab.n5.hdf5;
 
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -36,6 +37,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+
 import ch.systemsx.cisd.hdf5.HDF5Factory;
 import ch.systemsx.cisd.hdf5.IHDF5Reader;
 import ch.systemsx.cisd.hdf5.IHDF5Writer;
@@ -44,6 +46,7 @@ import ch.systemsx.cisd.hdf5.IHDF5Writer;
  *
  * @author Stephan Saalfeld
  * @author Igor Pisarev
+ * @author Philipp Hanslovsky
  */
 public class N5HDF5Test extends AbstractN5Test {
 
@@ -131,5 +134,51 @@ public class N5HDF5Test extends AbstractN5Test {
 		Assert.assertArrayEquals(defaultBlockSize, overriddenAttributes.getBlockSize());
 
 		hdf5Reader.close();
+	}
+
+	@Test
+	public void testDefaultBlockSizeGetter() throws IOException {
+		// do not pass array
+		{
+			try (final N5HDF5Reader h5  = new N5HDF5Writer(testDirPath)) {
+				Assert.assertArrayEquals(new int[]{}, h5.getDefaultBlockSizeCopy());
+			}
+		}
+		// pass array
+		{
+			try (final N5HDF5Reader h5 = new N5HDF5Writer(testDirPath, defaultBlockSize)) {
+				Assert.assertArrayEquals(defaultBlockSize, h5.getDefaultBlockSizeCopy());
+			}
+		}
+	}
+
+	@Test
+	public void testOverrideBlockSizeGetter() throws IOException {
+		// default behavior
+		{
+			try (final N5HDF5Reader h5 = new N5HDF5Writer(testDirPath)) {
+				Assert.assertFalse(h5.doesOverrideBlockSize());
+			}
+		}
+		// overrideBlockSize == false
+		{
+			try (final N5HDF5Reader h5 = new N5HDF5Reader(testDirPath, false)) {
+				Assert.assertFalse(h5.doesOverrideBlockSize());
+			}
+		}
+		// overrideBlockSize == false
+		{
+			try (final N5HDF5Reader h5 = new N5HDF5Reader(testDirPath, true)) {
+				Assert.assertTrue(h5.doesOverrideBlockSize());
+			}
+		}
+	}
+
+	@Test
+	public void testFilenameGetter() throws IOException {
+		try (final N5HDF5Reader h5  = new N5HDF5Writer(testDirPath)) {
+			Assert.assertEquals(new File(testDirPath), h5.getFilename());
+		}
+
 	}
 }


### PR DESCRIPTION
 - Useful for (de-)serialization
 - Implement Closeable (has close method already anyway)