### PR TITLE
Override N5HDF5Reader.toString

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
@@ -528,4 +528,9 @@ public class N5HDF5Reader implements N5Reader, Closeable {
 	public boolean doesOverrideBlockSize() {
 		return this.overrideBlockSize;
 	}
+
+	@Override
+	public String toString() {
+		return String.format("%s[file=%s]", getClass().getSimpleName(), reader.file().getFile());
+	}
 }


### PR DESCRIPTION
Useful for debugging

See also saalfeldlab/n5#54

```kotlin
println(N5HDF5Writer("${System.getProperty("user.home")}/Downloads/sample_A_20160501.hdf"))
println(N5HDF5Reader("${System.getProperty("user.home")}/Downloads/sample_A_20160501.hdf"))
```

```
N5HDF5Writer[file=/home/hanslovskyp/Downloads/sample_A_20160501.hdf]
N5HDF5Reader[file=/home/hanslovskyp/Downloads/sample_A_20160501.hdf]
```

cc @axtimwalde 