### PR TITLE
Block deletion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,8 @@
 	</ciManagement>
 
 	<properties>
+		<n5.version>2.2.0</n5.version>
+
 		<package-name>org.janelia.saalfeldlab</package-name>
 
 		<license.licenseName>bsd_2</license.licenseName>
@@ -102,7 +104,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
-			<version>2.1.3</version>
+			<version>${n5.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>cisd</groupId>
@@ -118,7 +120,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
-			<version>2.1.3</version>
+			<version>${n5.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Writer.java
@@ -31,12 +31,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.janelia.saalfeldlab.n5.Compression;
-import org.janelia.saalfeldlab.n5.DataBlock;
-import org.janelia.saalfeldlab.n5.DataType;
-import org.janelia.saalfeldlab.n5.DatasetAttributes;
-import org.janelia.saalfeldlab.n5.N5Writer;
-import org.janelia.saalfeldlab.n5.RawCompression;
+import org.janelia.saalfeldlab.n5.*;
 
 import ch.systemsx.cisd.base.mdarray.MDByteArray;
 import ch.systemsx.cisd.base.mdarray.MDDoubleArray;
@@ -291,6 +286,79 @@ public class N5HDF5Writer extends N5HDF5Reader implements N5Writer {
 			writer.float64().writeMDArrayBlockWithOffset(pathName, float64TargetCell, hdf5Offset);
 			break;
 		}
+	}
+
+	@Override
+	public boolean deleteBlock(String pathName, final long[] gridPosition) throws IOException {
+
+		// deletion is not supported in HDF5, so the block is overwritten with zeroes instead
+
+		if (pathName.equals(""))
+			pathName = "/";
+
+		final DatasetAttributes datasetAttributes = getDatasetAttributes(pathName);
+
+		final long[] hdf5Dimensions = datasetAttributes.getDimensions().clone();
+		reorder(hdf5Dimensions);
+		final int[] hdf5BlockSize = datasetAttributes.getBlockSize().clone();
+		reorder(hdf5BlockSize);
+		final long[] hdf5GridPosition = gridPosition.clone();
+		reorder(hdf5GridPosition);
+		final int[] hdf5CroppedBlockSize = new int[hdf5BlockSize.length];
+		final long[] hdf5Offset = new long[hdf5GridPosition.length];
+		cropBlockSize(
+				hdf5GridPosition,
+				hdf5Dimensions,
+				hdf5BlockSize,
+				hdf5CroppedBlockSize,
+				hdf5Offset);
+
+		switch (datasetAttributes.getDataType()) {
+			case UINT8:
+				final MDByteArray uint8TargetCell = new MDByteArray(hdf5CroppedBlockSize);
+				writer.uint8().writeMDArrayBlockWithOffset(pathName, uint8TargetCell, hdf5Offset);
+				break;
+			case INT8:
+				final MDByteArray int8TargetCell = new MDByteArray(hdf5CroppedBlockSize);
+				writer.int8().writeMDArrayBlockWithOffset(pathName, int8TargetCell, hdf5Offset);
+				break;
+			case UINT16:
+				final MDShortArray uint16TargetCell = new MDShortArray(hdf5CroppedBlockSize);
+				writer.uint16().writeMDArrayBlockWithOffset(pathName, uint16TargetCell, hdf5Offset);
+				break;
+			case INT16:
+				final MDShortArray int16TargetCell = new MDShortArray(hdf5CroppedBlockSize);
+				writer.int16().writeMDArrayBlockWithOffset(pathName, int16TargetCell, hdf5Offset);
+				break;
+			case UINT32:
+				final MDIntArray uint32TargetCell = new MDIntArray(hdf5CroppedBlockSize);
+				writer.uint32().writeMDArrayBlockWithOffset(pathName, uint32TargetCell, hdf5Offset);
+				break;
+			case INT32:
+				final MDIntArray int32TargetCell = new MDIntArray(hdf5CroppedBlockSize);
+				writer.int32().writeMDArrayBlockWithOffset(pathName, int32TargetCell, hdf5Offset);
+				break;
+			case UINT64:
+				final MDLongArray uint64TargetCell = new MDLongArray(hdf5CroppedBlockSize);
+				writer.uint64().writeMDArrayBlockWithOffset(pathName, uint64TargetCell, hdf5Offset);
+				break;
+			case INT64:
+				final MDLongArray int64TargetCell = new MDLongArray(hdf5CroppedBlockSize);
+				writer.int64().writeMDArrayBlockWithOffset(pathName, int64TargetCell, hdf5Offset);
+				break;
+			case FLOAT32:
+				final MDFloatArray float32TargetCell = new MDFloatArray(hdf5CroppedBlockSize);
+				writer.float32().writeMDArrayBlockWithOffset(pathName, float32TargetCell, hdf5Offset);
+				break;
+			case FLOAT64:
+				final MDDoubleArray float64TargetCell = new MDDoubleArray(hdf5CroppedBlockSize);
+				writer.float64().writeMDArrayBlockWithOffset(pathName, float64TargetCell, hdf5Offset);
+				break;
+			default:
+				return false;
+		}
+
+		return true;
 	}
 
 	@Override

--- a/src/test/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Test.java
@@ -25,15 +25,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
-import org.janelia.saalfeldlab.n5.AbstractN5Test;
-import org.janelia.saalfeldlab.n5.Compression;
-import org.janelia.saalfeldlab.n5.DataType;
-import org.janelia.saalfeldlab.n5.DatasetAttributes;
-import org.janelia.saalfeldlab.n5.GzipCompression;
-import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.*;
 import org.janelia.saalfeldlab.n5.N5Reader.Version;
-import org.janelia.saalfeldlab.n5.N5Writer;
-import org.janelia.saalfeldlab.n5.RawCompression;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -116,6 +109,27 @@ public class N5HDF5Test extends AbstractN5Test {
 	@Test
 	@Ignore("HDF5 does not currently support mode 1 data blocks.")
 	public void testMode1WriteReadByteBlock() {
+	}
+
+	@Override
+	protected boolean testDeleteIsBlockDeleted(final DataBlock<?> dataBlock) {
+
+		// deletion is not supported in HDF5, so the block is overwritten with zeroes instead
+
+		if (dataBlock instanceof ByteArrayDataBlock)
+			return Arrays.equals((byte[]) dataBlock.getData(), new byte[dataBlock.getNumElements()]);
+		else if (dataBlock instanceof ShortArrayDataBlock)
+			return Arrays.equals((short[]) dataBlock.getData(), new short[dataBlock.getNumElements()]);
+		else if (dataBlock instanceof IntArrayDataBlock)
+			return Arrays.equals((int[]) dataBlock.getData(), new int[dataBlock.getNumElements()]);
+		else if (dataBlock instanceof LongArrayDataBlock)
+			return Arrays.equals((long[]) dataBlock.getData(), new long[dataBlock.getNumElements()]);
+		else if (dataBlock instanceof FloatArrayDataBlock)
+			return Arrays.equals((float[]) dataBlock.getData(), new float[dataBlock.getNumElements()]);
+		else if (dataBlock instanceof DoubleArrayDataBlock)
+			return Arrays.equals((double[]) dataBlock.getData(), new double[dataBlock.getNumElements()]);
+
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
This PR adds block deletion functionality introduced in N5 2.2.0.

HDF5 doesn't allow to actually delete a chunk of data, so the block is filled with zeroes instead to indicate that it's empty.