### PR TITLE
Update to pom-scijava 32

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -13,24 +13,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Cache m2 folder
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-m2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
+      - name: Set up Java
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'zulu'
+          cache: 'maven'
       - name: Set up CI environment
         run: .github/setup.sh
       - name: Execute the build

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -11,24 +11,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Cache m2 folder
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-m2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
+      - name: Set up Java
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'zulu'
+          cache: 'maven'
       - name: Set up CI environment
         run: .github/setup.sh
       - name: Execute the build

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>31.1.0</version>
+		<version>32.0.0-beta-5</version>
 		<relativePath />
 	</parent>
 
@@ -86,19 +86,23 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
+		<!-- TEMP: Inheriting n5 2.5.1 breaks behavior. -->
 		<n5.version>2.4.0</n5.version>
-		<cisd.jhdf5.version>19.04.0</cisd.jhdf5.version>
 	</properties>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>cisd</groupId>
 			<artifactId>jhdf5</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
 		</dependency>
 
 		<!-- Test dependencies -->
@@ -110,20 +114,9 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
-			<version>${n5.version}</version>
+			<version>${org.janelia.saalfeldlab.n5.version}</version>
 			<classifier>tests</classifier>
 			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>cisd</groupId>
-			<artifactId>jhdf5</artifactId>
-			<version>${cisd.jhdf5.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,6 @@
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
-
-		<!-- TEMP: Inheriting n5 2.5.1 breaks behavior. -->
-		<n5.version>2.4.0</n5.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
This makes n5-hdf5 harmonious with the rest of the SciJava component collection at pom-scijava 32.0.0.

Unfortunately, the update of n5 from 2.4.0 to 2.5.1 breaks n5-hdf's tests. Maybe something changed in n5?