### PR TITLE
Update to pom-scijava 32, fixing tests

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -13,24 +13,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Cache m2 folder
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-m2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
+      - name: Set up Java
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'zulu'
+          cache: 'maven'
       - name: Set up CI environment
         run: .github/setup.sh
       - name: Execute the build

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -11,24 +11,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Cache m2 folder
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-m2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
+      - name: Set up Java
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'zulu'
+          cache: 'maven'
       - name: Set up CI environment
         run: .github/setup.sh
       - name: Execute the build

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>31.1.0</version>
+		<version>32.0.0-beta-5</version>
 		<relativePath />
 	</parent>
 
@@ -86,19 +86,23 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
+		<!-- TEMP: Inheriting n5 2.5.1 breaks behavior. -->
 		<n5.version>2.4.0</n5.version>
-		<cisd.jhdf5.version>19.04.0</cisd.jhdf5.version>
 	</properties>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>cisd</groupId>
 			<artifactId>jhdf5</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
 		</dependency>
 
 		<!-- Test dependencies -->
@@ -110,20 +114,9 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
-			<version>${n5.version}</version>
+			<version>${org.janelia.saalfeldlab.n5.version}</version>
 			<classifier>tests</classifier>
 			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>cisd</groupId>
-			<artifactId>jhdf5</artifactId>
-			<version>${cisd.jhdf5.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,6 @@
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
-
-		<!-- TEMP: Inheriting n5 2.5.1 breaks behavior. -->
-		<n5.version>2.4.0</n5.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
@@ -549,7 +549,7 @@ public class N5HDF5Reader implements N5Reader, GsonAttributesParser, Closeable {
 					}
 					attrs.put(k, elem);
 				}
-				
+
 			} else
 				attrs.put(k, gson.toJsonTree(getAttribute(pathName, k, attrClasses.get(k))));
 		}

--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
@@ -54,6 +54,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 
 import ch.systemsx.cisd.base.mdarray.MDByteArray;
@@ -529,12 +530,14 @@ public class N5HDF5Reader implements N5Reader, GsonAttributesParser, Closeable {
 		final HashMap<String, JsonElement> attrs = new HashMap<>();
 		final Map<String, Class<?>> attrClasses = listAttributes(pathName);
 		for (final String k : attrClasses.keySet()) {
-			if (attrClasses.get(k).equals(String.class)) {
-
+			if (
+					attrClasses.get(k).equals(Object.class) ||
+					attrClasses.get(k).equals(Object[].class)
+			) {
 				final String s = getAttribute(pathName, k, String.class);
 
 				if (s.isEmpty()) {
-					// check for empty string explicitly because it parsese
+					// check for empty string explicitly because it parses
 					// as a null JsonObject without throwing an exception
 					attrs.put(k, gson.toJsonTree(s));
 				} else {
@@ -546,7 +549,7 @@ public class N5HDF5Reader implements N5Reader, GsonAttributesParser, Closeable {
 					}
 					attrs.put(k, elem);
 				}
-
+				
 			} else
 				attrs.put(k, gson.toJsonTree(getAttribute(pathName, k, attrClasses.get(k))));
 		}
@@ -792,8 +795,10 @@ public class N5HDF5Reader implements N5Reader, GsonAttributesParser, Closeable {
 	}
 
 	/**
-	 * Structured attributes that are stored as JSON will be classified as
-	 * String.class.
+	 * String attributes will be parsed as JSON and classified as
+	 * 1) An Object[] if it is a JsonArray
+	 * 2) A  String   if it is a JsonPrimitive
+	 * 3) An Object   if it is a JsonObject
 	 */
 	@Override
 	public Map<String, Class<?>> listAttributes(final String pathName) throws IOException {
@@ -801,17 +806,37 @@ public class N5HDF5Reader implements N5Reader, GsonAttributesParser, Closeable {
 		final String finalPathName = pathName.equals("") ? "/" : pathName;
 
 		final HashMap<String, Class<?>> attributes = new HashMap<>();
+		
 		reader
 				.object()
 				.getAttributeNames(finalPathName)
 				.forEach(
-						attributeName -> attributes
+						attributeName -> {
+							Class<?> clazz = reader
+								.object()
+								.getAttributeInformation(finalPathName, attributeName)
+								.tryGetJavaType();
+							if(clazz.isAssignableFrom(String.class)) {
+								//Attempt to parse the JSON
+								try {
+									String value = reader.string().getAttr(finalPathName, attributeName);
+									JsonElement element = JsonParser.parseString(value);
+									if(element.isJsonArray())
+										clazz = Object[].class;
+									else if(!element.isJsonPrimitive())
+										clazz = Object.class;
+									//A plain String is a JSON primitive
+								} catch(JsonSyntaxException e) {
+									//parsing fail, assume String.class
+								}
+							}
+							attributes
 								.put(
 										attributeName,
-										reader
-												.object()
-												.getAttributeInformation(finalPathName, attributeName)
-												.tryGetJavaType()));
+										clazz
+								);
+						}
+				);
 		return attributes;
 	}
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Test.java
@@ -19,10 +19,12 @@ package org.janelia.saalfeldlab.n5.hdf5;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -125,6 +127,25 @@ public class N5HDF5Test extends AbstractN5Test {
 		Files.createDirectories(Paths.get(testDirPath).getParent());
 		hdf5Writer = HDF5Factory.open(testDirPath);
 		return new N5HDF5Writer(hdf5Writer);
+	}
+	
+	@Override
+	@Test
+	public void testCreateGroup() {
+
+		try {
+			n5.createGroup(groupName);
+		} catch (final IOException e) {
+			fail(e.getMessage());
+		}
+
+		final Path groupPath = Paths.get(groupName);
+		for (int i = 0; i < groupPath.getNameCount(); ++i)
+			//replace `\` with `/` in the case of Windows
+			if (!n5.exists(groupPath.subpath(0, i + 1)
+					.toString()
+					.replace(File.separatorChar, '/')))
+				fail("Group does not exist");
 	}
 
 	@Override

--- a/src/test/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Test.java
@@ -28,6 +28,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.function.Predicate;
 
 import org.janelia.saalfeldlab.n5.AbstractN5Test;
 import org.janelia.saalfeldlab.n5.ByteArrayDataBlock;
@@ -355,5 +360,212 @@ public class N5HDF5Test extends AbstractN5Test {
 	@Test
 	public void testType() {
 		System.out.println(new TypeToken<DataType>() {}.getType().getTypeName());
+	}
+	
+	@Override
+	@Test
+	/*
+	 * Differs from AbstractN5Test since an int will be read back as int, not a long
+	 */
+	public void testListAttributes() {
+
+		final String groupName2 = groupName + "-2";
+		final String datasetName2 = datasetName + "-2";
+		try {
+			n5.createDataset(datasetName2, dimensions, blockSize, DataType.UINT64, new RawCompression());
+			n5.setAttribute(datasetName2, "attr1", new double[] {1.1, 2.1, 3.1});
+			n5.setAttribute(datasetName2, "attr2", new String[] {"a", "b", "c"});
+			n5.setAttribute(datasetName2, "attr3", 1.1);
+			n5.setAttribute(datasetName2, "attr4", "a");
+			n5.setAttribute(datasetName2, "attr5", new long[] {1, 2, 3});
+			n5.setAttribute(datasetName2, "attr6", 1);
+			n5.setAttribute(datasetName2, "attr7", new double[] {1, 2, 3.1});
+			n5.setAttribute(datasetName2, "attr8", new Object[] {"1", 2, 3.1});
+
+			Map<String, Class<?>> attributesMap = n5.listAttributes(datasetName2);
+			Assert.assertTrue(attributesMap.get("attr1") == double[].class);
+			Assert.assertTrue(attributesMap.get("attr2") == String[].class);
+			Assert.assertTrue(attributesMap.get("attr3") == double.class);
+			Assert.assertTrue(attributesMap.get("attr4") == String.class);
+			Assert.assertTrue(attributesMap.get("attr5") == long[].class);
+			//HDF5 will parse an int as an int rather than a long
+			Assert.assertTrue(attributesMap.get("attr6") == int.class);
+			Assert.assertTrue(attributesMap.get("attr7") == double[].class);
+			Assert.assertTrue(attributesMap.get("attr8") == Object[].class);
+
+			n5.createGroup(groupName2);
+			n5.setAttribute(groupName2, "attr1", new double[] {1.1, 2.1, 3.1});
+			n5.setAttribute(groupName2, "attr2", new String[] {"a", "b", "c"});
+			n5.setAttribute(groupName2, "attr3", 1.1);
+			n5.setAttribute(groupName2, "attr4", "a");
+			n5.setAttribute(groupName2, "attr5", new long[] {1, 2, 3});
+			n5.setAttribute(groupName2, "attr6", 1);
+			n5.setAttribute(groupName2, "attr7", new double[] {1, 2, 3.1});
+			n5.setAttribute(groupName2, "attr8", new Object[] {"1", 2, 3.1});
+
+			attributesMap = n5.listAttributes(groupName2);
+			Assert.assertTrue(attributesMap.get("attr1") == double[].class);
+			Assert.assertTrue(attributesMap.get("attr2") == String[].class);
+			Assert.assertTrue(attributesMap.get("attr3") == double.class);
+			Assert.assertTrue(attributesMap.get("attr4") == String.class);
+			Assert.assertTrue(attributesMap.get("attr5") == long[].class);
+			//HDF5 will parse an int as an int rather than a long
+			Assert.assertTrue(attributesMap.get("attr6") == int.class);
+			Assert.assertTrue(attributesMap.get("attr7") == double[].class);
+			Assert.assertTrue(attributesMap.get("attr8") == Object[].class);
+		} catch (final IOException e) {
+			fail(e.getMessage());
+		}
+	}
+	
+	@Override
+	@Test
+	public void testDeepList() {
+		try {
+
+			// clear container to start
+			n5.remove();
+			// create a new container since the above removes the file
+			n5 = createN5Writer();
+
+			n5.createGroup(groupName);
+			for (final String subGroup : subGroupNames)
+				n5.createGroup(groupName + "/" + subGroup);
+
+			final List<String> groupsList = Arrays.asList(n5.deepList("/"));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", groupsList.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
+
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", Arrays.asList(n5.deepList("")).contains(groupName.replaceFirst("/", "") + "/" + subGroup));
+
+			final DatasetAttributes datasetAttributes = new DatasetAttributes(dimensions, blockSize, DataType.UINT64, new RawCompression());
+			final LongArrayDataBlock dataBlock = new LongArrayDataBlock( blockSize, new long[]{0,0,0}, new long[blockNumElements] );
+			n5.createDataset(datasetName, datasetAttributes );
+			n5.writeBlock(datasetName, datasetAttributes, dataBlock);
+
+			final List<String> datasetList = Arrays.asList(n5.deepList("/"));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", datasetList.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
+			Assert.assertFalse("deepList stops at datasets", datasetList.contains(datasetName + "/0"));
+
+			final List<String> datasetList2 = Arrays.asList(n5.deepList(""));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", datasetList2.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
+			Assert.assertTrue("deepList contents", datasetList2.contains(datasetName.replaceFirst("/", "")));
+			Assert.assertFalse("deepList stops at datasets", datasetList2.contains(datasetName + "/0"));
+
+			final String prefix = "/test";
+			final String datasetSuffix = "group/dataset";
+			final List<String> datasetList3 = Arrays.asList(n5.deepList(prefix));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", datasetList3.contains("group/" + subGroup));
+			Assert.assertTrue("deepList contents", datasetList3.contains(datasetName.replaceFirst(prefix + "/", "")));
+
+			// parallel deepList tests
+			final List<String> datasetListP = Arrays.asList(n5.deepList("/", Executors.newFixedThreadPool(2)));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", datasetListP.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
+			Assert.assertTrue("deepList contents", datasetListP.contains(datasetName.replaceFirst("/", "")));
+			Assert.assertFalse("deepList stops at datasets", datasetListP.contains(datasetName + "/0"));
+
+			final List<String> datasetListP2 = Arrays.asList(n5.deepList("", Executors.newFixedThreadPool(2)));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", datasetListP2.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
+			Assert.assertTrue("deepList contents", datasetListP2.contains(datasetName.replaceFirst("/", "")));
+			Assert.assertFalse("deepList stops at datasets", datasetListP2.contains(datasetName + "/0"));
+
+			final List<String> datasetListP3 = Arrays.asList(n5.deepList(prefix, Executors.newFixedThreadPool(2)));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", datasetListP3.contains("group/" + subGroup));
+			Assert.assertTrue("deepList contents", datasetListP3.contains(datasetName.replaceFirst(prefix + "/", "")));
+			Assert.assertFalse("deepList stops at datasets", datasetListP3.contains(datasetName + "/0"));
+
+			// test filtering
+			final Predicate<String> isCalledDataset = d -> {
+				return d.endsWith("/dataset");
+			};
+			final Predicate<String> isBorC = d -> {
+				return d.matches(".*/[bc]$");
+			};
+
+			final List<String> datasetListFilter1 = Arrays.asList(n5.deepList(prefix, isCalledDataset));
+			Assert.assertTrue(
+					"deepList filter \"dataset\"",
+					datasetListFilter1.stream().map(x -> prefix + x).allMatch(isCalledDataset));
+
+			final List<String> datasetListFilter2 = Arrays.asList(n5.deepList(prefix, isBorC));
+			Assert.assertTrue(
+					"deepList filter \"b or c\"",
+					datasetListFilter2.stream().map(x -> prefix + x).allMatch(isBorC));
+
+			final List<String> datasetListFilterP1 =
+					Arrays.asList(n5.deepList(prefix, isCalledDataset, Executors.newFixedThreadPool(2)));
+			Assert.assertTrue(
+					"deepList filter \"dataset\"",
+					datasetListFilterP1.stream().map(x -> prefix + x).allMatch(isCalledDataset));
+
+			final List<String> datasetListFilterP2 =
+					Arrays.asList(n5.deepList(prefix, isBorC, Executors.newFixedThreadPool(2)));
+			Assert.assertTrue(
+					"deepList filter \"b or c\"",
+					datasetListFilterP2.stream().map(x -> prefix + x).allMatch(isBorC));
+
+			// test dataset filtering
+			final List<String> datasetListFilterD = Arrays.asList(n5.deepListDatasets(prefix));
+			Assert.assertTrue(
+					"deepListDataset",
+					datasetListFilterD.size() == 1 && (prefix + "/" + datasetListFilterD.get(0)).equals(datasetName));
+			Assert.assertArrayEquals(
+					datasetListFilterD.toArray(),
+					n5.deepList(
+							prefix,
+							a -> {
+								try { return n5.datasetExists(a); }
+								catch (final IOException e) { return false; }
+							}));
+
+			final List<String> datasetListFilterDandBC = Arrays.asList(n5.deepListDatasets(prefix, isBorC));
+			Assert.assertTrue("deepListDatasetFilter", datasetListFilterDandBC.size() == 0);
+			Assert.assertArrayEquals(
+					datasetListFilterDandBC.toArray(),
+					n5.deepList(
+							prefix,
+							a -> {
+								try { return n5.datasetExists(a) && isBorC.test(a); }
+								catch (final IOException e) { return false; }
+							}));
+
+			final List<String> datasetListFilterDP =
+					Arrays.asList(n5.deepListDatasets(prefix, Executors.newFixedThreadPool(2)));
+			Assert.assertTrue(
+					"deepListDataset Parallel",
+					datasetListFilterDP.size() == 1 && (prefix + "/" + datasetListFilterDP.get(0)).equals(datasetName));
+			Assert.assertArrayEquals(
+					datasetListFilterDP.toArray(),
+					n5.deepList(
+							prefix,
+							a -> {
+								try { return n5.datasetExists(a); }
+								catch (final IOException e) { return false; }
+							},
+							Executors.newFixedThreadPool(2)));
+
+			final List<String> datasetListFilterDandBCP =
+					Arrays.asList(n5.deepListDatasets(prefix, isBorC, Executors.newFixedThreadPool(2)));
+			Assert.assertTrue("deepListDatasetFilter Parallel", datasetListFilterDandBCP.size() == 0);
+			Assert.assertArrayEquals(
+					datasetListFilterDandBCP.toArray(),
+					n5.deepList(
+							prefix,
+							a -> {
+								try { return n5.datasetExists(a) && isBorC.test(a); }
+								catch (final IOException e) { return false; }
+							},
+							Executors.newFixedThreadPool(2)));
+
+		} catch (final IOException | InterruptedException | ExecutionException e) {
+			fail(e.getMessage());
+		}
 	}
 }


### PR DESCRIPTION
Supersedes #19 by fixing the following tests
* `testCreateGroup`: The path separator is changed to always be `/`
* `testListAttributes`: `int` is expected to be an `int` rather than a `long`. `listAttributes` now attempts to parse JSON.
* `testDeepList`: recreates the HDF5 file after removing it