### PR TITLE
Support for variable length string arrays

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
@@ -25,6 +25,7 @@
  */
 package org.janelia.saalfeldlab.n5.hdf5;
 
+import ch.systemsx.cisd.base.mdarray.MDArray;
 import ch.systemsx.cisd.hdf5.HDF5DataSetInformation;
 import ch.systemsx.cisd.hdf5.HDF5DataTypeInformation;
 import ch.systemsx.cisd.hdf5.HDF5Factory;
@@ -49,6 +50,7 @@ import org.janelia.saalfeldlab.n5.N5Exception;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5URI;
 import org.janelia.saalfeldlab.n5.RawCompression;
+import org.janelia.saalfeldlab.n5.StringDataBlock;
 import org.janelia.saalfeldlab.n5.hdf5.N5HDF5Util.OpenDataSetCache;
 import org.janelia.saalfeldlab.n5.hdf5.N5HDF5Util.OpenDataSetCache.OpenDataSet;
 import org.scijava.util.VersionUtils;
@@ -60,6 +62,7 @@ import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.FileSystems;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -677,6 +680,12 @@ public class N5HDF5Reader implements GsonN5Reader, Closeable {
 
 		final long[] hdf5CroppedBlockSize = reorderToLong(croppedBlockSize);
 		reorder(hdf5Offset);
+
+		if (datasetAttributes.getDataType() == DataType.STRING) {
+			final int[] intHdf5CroppedBlockSize = Arrays.stream(hdf5CroppedBlockSize).mapToInt(i -> (int)i).toArray();
+			MDArray<String> data = reader.string().readMDArrayBlockWithOffset(normalizedPathName, intHdf5CroppedBlockSize, hdf5Offset);
+			return new StringDataBlock(croppedBlockSize, gridPosition, data.getAsFlatArray());
+		}
 
 		final DataType dataType = datasetAttributes.getDataType();
 		final long memTypeId;

--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
@@ -48,6 +48,7 @@ import org.janelia.saalfeldlab.n5.LongArrayDataBlock;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.RawCompression;
 import org.janelia.saalfeldlab.n5.ShortArrayDataBlock;
+import org.janelia.saalfeldlab.n5.VLenStringDataBlock;
 import org.scijava.util.VersionUtils;
 
 import com.google.gson.Gson;
@@ -57,6 +58,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 
+import ch.systemsx.cisd.base.mdarray.MDArray;
 import ch.systemsx.cisd.base.mdarray.MDByteArray;
 import ch.systemsx.cisd.base.mdarray.MDDoubleArray;
 import ch.systemsx.cisd.base.mdarray.MDFloatArray;
@@ -595,6 +597,8 @@ public class N5HDF5Reader implements N5Reader, GsonAttributesParser, Closeable {
 			return DataType.FLOAT64;
 		else if (type.isAssignableFrom(float.class))
 			return DataType.FLOAT32;
+		else if (type.isAssignableFrom(String.class))
+			return DataType.VLENSTRING;
 
 		System.err.println("Datasets of type " + typeInfo + " not yet implemented.");
 		return null;
@@ -777,6 +781,12 @@ public class N5HDF5Reader implements N5Reader, GsonAttributesParser, Closeable {
 					.float64()
 					.readMDArrayBlockWithOffset(pathName, hdf5CroppedBlockSize, hdf5Offset);
 			dataBlock = new DoubleArrayDataBlock(croppedBlockSize, gridPosition, float64Array.getAsFlatArray());
+			break;
+		case VLENSTRING:
+			final MDArray<String> vlenStringArray = reader
+					.string()
+					.readMDArrayBlockWithOffset(pathName, hdf5CroppedBlockSize, hdf5Offset);
+			dataBlock = new VLenStringDataBlock(croppedBlockSize, gridPosition, vlenStringArray.getAsFlatArray());
 			break;
 		default:
 			dataBlock = null;

--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
@@ -177,11 +177,10 @@ public class N5HDF5Reader implements GsonN5Reader, Closeable {
 	 * @param defaultBlockSize for all dimensions &gt; defaultBlockSize.length, and for all
 	 *                         dimensions with defaultBlockSize[i] &lt;= 0, the size of the
 	 *                         dataset will be used
-	 * @throws IOException the exception
 	 */
 	public N5HDF5Reader(
 			final IHDF5Reader reader,
-			final int... defaultBlockSize) throws IOException {
+			final int... defaultBlockSize) {
 
 		this(reader, false, defaultBlockSize);
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Reader.java
@@ -561,7 +561,7 @@ public class N5HDF5Reader implements GsonN5Reader, Closeable {
 		else if (type.isAssignableFrom(float.class))
 			return DataType.FLOAT32;
 		else if (type.isAssignableFrom(String.class))
-			return DataType.VLENSTRING;
+			return DataType.STRING;
 
 		System.err.println("Datasets of type " + typeInfo + " not yet implemented.");
 		return null;

--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Util.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Util.java
@@ -56,7 +56,7 @@ final class N5HDF5Util {
 			return H5T_NATIVE_FLOAT;
 		case FLOAT64:
 			return H5T_NATIVE_DOUBLE;
-		case VLENSTRING:
+		case STRING:
 			return H5T_VLEN;
 		default:
 			throw new IllegalArgumentException();

--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Util.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Util.java
@@ -27,7 +27,6 @@ import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_UINT16;
 import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_UINT32;
 import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_UINT64;
 import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_UINT8;
-import static hdf.hdf5lib.HDF5Constants.H5T_VLEN;
 
 final class N5HDF5Util {
 
@@ -57,7 +56,7 @@ final class N5HDF5Util {
 		case FLOAT64:
 			return H5T_NATIVE_DOUBLE;
 		case STRING:
-			return H5T_VLEN;
+			throw new IllegalStateException("MemTypeId for STRING is not defined and should not be queried.");
 		default:
 			throw new IllegalArgumentException();
 		}

--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Writer.java
@@ -25,6 +25,7 @@
  */
 package org.janelia.saalfeldlab.n5.hdf5;
 
+import ch.systemsx.cisd.base.mdarray.MDArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 
@@ -521,6 +522,12 @@ public class N5HDF5Writer extends N5HDF5Reader implements GsonN5Writer {
 
 		final long[] hdf5DataBlockSize = reorderToLong(dataBlock.getSize());
 		final long[] hdf5Offset = reorderMultiplyToLong(dataBlock.getGridPosition(), datasetAttributes.getBlockSize());
+
+		if (datasetAttributes.getDataType() == DataType.STRING) {
+			MDArray<String> arr = new MDArray<>((String[]) dataBlock.getData(), hdf5DataBlockSize);
+			writer.string().writeMDArrayBlockWithOffset(pathName, arr, hdf5Offset);
+			return;
+		}
 
 		try (OpenDataSet dataset = openDataSetCache.get(pathName)) {
 			final long memorySpaceId = H5Screate_simple(hdf5DataBlockSize.length, hdf5DataBlockSize, null);

--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Writer.java
@@ -273,7 +273,7 @@ public class N5HDF5Writer extends N5HDF5Reader implements GsonN5Writer {
 		case FLOAT64:
 			writer.float64().createMDArray(pathName, hdf5Dimensions, hdf5BlockSize, floatCompression);
 			break;
-		case VLENSTRING:
+		case STRING:
 			writer.string().createMDArrayVL(pathName, hdf5Dimensions, hdf5BlockSize, stringCompression);
 		default:
 			return;

--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Writer.java
@@ -319,7 +319,7 @@ public class N5HDF5Writer extends N5HDF5Reader implements GsonN5Writer {
 		final String[] attributePathTokens = normalizedKey.split("/");
 		final boolean isPath =
 				attributePathTokens.length > 2
-						|| attributePathTokens.length > 1 && attributePathTokens[0].length() > 0
+						|| attributePathTokens.length > 1 && !attributePathTokens[0].isEmpty()
 						|| N5URI.ARRAY_INDEX.asPredicate().test(normalizedKey)
 						|| containsEscapeCharacters(normalizedKey);
 		if (isRoot || isPath ) {

--- a/src/test/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Test.java
@@ -20,6 +20,7 @@ package org.janelia.saalfeldlab.n5.hdf5;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -72,7 +73,7 @@ import ch.systemsx.cisd.hdf5.IHDF5Reader;
  */
 public class N5HDF5Test extends AbstractN5Test {
 
-	private static int[] defaultBlockSize = new int[]{5, 6, 7};
+	private static final int[] defaultBlockSize = new int[]{5, 6, 7};
 	public static class Structured {
 
 		public String name = "";
@@ -107,7 +108,7 @@ public class N5HDF5Test extends AbstractN5Test {
 		return Files.createTempFile("n5-hdf5-test-", ".hdf5").toFile().getCanonicalPath();
 	}
 
-	@Override protected N5HDF5Writer createN5Writer() throws IOException, URISyntaxException {
+	@Override protected N5HDF5Writer createN5Writer() throws IOException {
 
 		final String location = tempN5Location();
 		final String hdf5Path = resolveTestHdf5Path(location);
@@ -193,7 +194,7 @@ public class N5HDF5Test extends AbstractN5Test {
 
 	@Override
 	@Test
-	public void testVersion() throws NumberFormatException, IOException, URISyntaxException {
+	public void testVersion() throws NumberFormatException, IOException {
 
 		try (N5Writer n5 = createN5Writer()) {
 
@@ -214,7 +215,7 @@ public class N5HDF5Test extends AbstractN5Test {
 
 	@Override
 	@Test
-	public void testSetAttributeDoesntCreateGroup() throws IOException, URISyntaxException {
+	public void testSetAttributeDoesntCreateGroup() throws IOException {
 
 		try (final N5Writer writer = createN5Writer()) {
 			final String testGroup = "/group/should/not/exit";
@@ -225,7 +226,7 @@ public class N5HDF5Test extends AbstractN5Test {
 	}
 
 	@Test
-	public void testOverrideBlockSize() throws IOException, URISyntaxException {
+	public void testOverrideBlockSize() throws IOException {
 
 		try (N5Writer n5HDF5Writer = createN5Writer()) {
 			final String testFilePath = n5HDF5Writer.getURI().getPath();
@@ -246,7 +247,7 @@ public class N5HDF5Test extends AbstractN5Test {
 	}
 
 	@Test
-	public void testDefaultBlockSizeGetter() throws IOException, URISyntaxException {
+	public void testDefaultBlockSizeGetter() throws IOException {
 		// do not pass array
 		{
 			try (final N5HDF5Writer h5 = createN5Writer()) {
@@ -263,7 +264,7 @@ public class N5HDF5Test extends AbstractN5Test {
 	}
 
 	@Test
-	public void testOverrideBlockSizeGetter() throws IOException, URISyntaxException {
+	public void testOverrideBlockSizeGetter() throws IOException {
 		// default behavior
 		try (final N5HDF5Writer h5 = createN5Writer()) {
 			final String testFilePath = h5.getURI().getPath();
@@ -280,7 +281,7 @@ public class N5HDF5Test extends AbstractN5Test {
 	}
 
 	@Test
-	public void testFilenameGetter() throws IOException, URISyntaxException {
+	public void testFilenameGetter() throws IOException {
 
 		try (final N5HDF5Writer h5 = createN5Writer()) {
 			final String testFilePath = h5.getURI().getPath();
@@ -290,7 +291,7 @@ public class N5HDF5Test extends AbstractN5Test {
 	}
 
 	@Test
-	public void testStructuredAttributes() throws IOException, URISyntaxException {
+	public void testStructuredAttributes() throws IOException {
 
 		try (N5Writer n5 = createN5Writer()) {
 			final Structured attribute = new Structured();
@@ -399,7 +400,7 @@ public class N5HDF5Test extends AbstractN5Test {
 	/*
 	 * Differs from AbstractN5Test since an int will be read back as int, not a long
 	 */
-	public void testListAttributes() throws IOException, URISyntaxException {
+	public void testListAttributes() throws IOException {
 
 		try (N5Writer n5 = createN5Writer()) {
 
@@ -416,15 +417,15 @@ public class N5HDF5Test extends AbstractN5Test {
 			n5.setAttribute(datasetName2, "attr8", new Object[] {"1", 2, 3.1});
 
 			Map<String, Class<?>> attributesMap = n5.listAttributes(datasetName2);
-			assertTrue(attributesMap.get("attr1") == double[].class);
-			assertTrue(attributesMap.get("attr2") == String[].class);
-			assertTrue(attributesMap.get("attr3") == double.class);
-			assertTrue(attributesMap.get("attr4") == String.class);
-			assertTrue(attributesMap.get("attr5") == long[].class);
+			assertSame(attributesMap.get("attr1"), double[].class);
+			assertSame(attributesMap.get("attr2"), String[].class);
+			assertSame(attributesMap.get("attr3"), double.class);
+			assertSame(attributesMap.get("attr4"), String.class);
+			assertSame(attributesMap.get("attr5"), long[].class);
 			//HDF5 will parse an int as an int rather than a long
-			assertTrue(attributesMap.get("attr6") == int.class);
-			assertTrue(attributesMap.get("attr7") == double[].class);
-			assertTrue(attributesMap.get("attr8") == Object[].class);
+			assertSame(attributesMap.get("attr6"), int.class);
+			assertSame(attributesMap.get("attr7"), double[].class);
+			assertSame(attributesMap.get("attr8"), Object[].class);
 
 			n5.createGroup(groupName2);
 			n5.setAttribute(groupName2, "attr1", new double[] {1.1, 2.1, 3.1});
@@ -437,15 +438,15 @@ public class N5HDF5Test extends AbstractN5Test {
 			n5.setAttribute(groupName2, "attr8", new Object[] {"1", 2, 3.1});
 
 			attributesMap = n5.listAttributes(groupName2);
-			assertTrue(attributesMap.get("attr1") == double[].class);
-			assertTrue(attributesMap.get("attr2") == String[].class);
-			assertTrue(attributesMap.get("attr3") == double.class);
-			assertTrue(attributesMap.get("attr4") == String.class);
-			assertTrue(attributesMap.get("attr5") == long[].class);
+			assertSame(attributesMap.get("attr1"), double[].class);
+			assertSame(attributesMap.get("attr2"), String[].class);
+			assertSame(attributesMap.get("attr3"), double.class);
+			assertSame(attributesMap.get("attr4"), String.class);
+			assertSame(attributesMap.get("attr5"), long[].class);
 			//HDF5 will parse an int as an int rather than a long
-			assertTrue(attributesMap.get("attr6") == int.class);
-			assertTrue(attributesMap.get("attr7") == double[].class);
-			assertTrue(attributesMap.get("attr8") == Object[].class);
+			assertSame(attributesMap.get("attr6"), int.class);
+			assertSame(attributesMap.get("attr7"), double[].class);
+			assertSame(attributesMap.get("attr8"), Object[].class);
 		}
 	}
 }

--- a/src/test/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Test.java
@@ -57,7 +57,6 @@ import org.junit.Test;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 
 import ch.systemsx.cisd.hdf5.HDF5Factory;


### PR DESCRIPTION
This is the HDF5 implementation of the [corresponding pull request in the base N5 repository](https://github.com/saalfeldlab/n5/pull/94). To compile, the .jar files from the issue in the base repository are needed.

All this does is calling the appropriate `writer` from jhdf5.