### PR TITLE
Cache open datasets for reading and writing blocks

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Util.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Util.java
@@ -1,0 +1,197 @@
+package org.janelia.saalfeldlab.n5.hdf5;
+
+import ch.systemsx.cisd.hdf5.IHDF5FileLevelReadOnlyHandler;
+import ch.systemsx.cisd.hdf5.IHDF5Reader;
+import ch.systemsx.cisd.hdf5.hdf5lib.HDFHelper;
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.janelia.saalfeldlab.n5.DataType;
+
+import static hdf.hdf5lib.H5.H5Dclose;
+import static hdf.hdf5lib.H5.H5Dopen;
+import static hdf.hdf5lib.H5.H5Fclose;
+import static hdf.hdf5lib.H5.H5Fopen;
+import static hdf.hdf5lib.H5.H5Pclose;
+import static hdf.hdf5lib.H5.H5open;
+import static hdf.hdf5lib.HDF5Constants.H5F_ACC_RDONLY;
+import static hdf.hdf5lib.HDF5Constants.H5P_DEFAULT;
+import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_DOUBLE;
+import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_FLOAT;
+import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_INT16;
+import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_INT32;
+import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_INT64;
+import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_INT8;
+import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_UINT16;
+import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_UINT32;
+import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_UINT64;
+import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_UINT8;
+
+final class N5HDF5Util {
+
+	private N5HDF5Util() {}
+
+	// TODO: make public and move to N5HDF5Utils?
+	static long memTypeId(final DataType dataType) {
+		switch (dataType) {
+		case INT8:
+			return H5T_NATIVE_INT8;
+		case UINT8:
+			return H5T_NATIVE_UINT8;
+		case INT16:
+			return H5T_NATIVE_INT16;
+		case UINT16:
+			return H5T_NATIVE_UINT16;
+		case INT32:
+			return H5T_NATIVE_INT32;
+		case UINT32:
+			return H5T_NATIVE_UINT32;
+		case INT64:
+			return H5T_NATIVE_INT64;
+		case UINT64:
+			return H5T_NATIVE_UINT64;
+		case FLOAT32:
+			return H5T_NATIVE_FLOAT;
+		case FLOAT64:
+			return H5T_NATIVE_DOUBLE;
+		default:
+			throw new IllegalArgumentException();
+		}
+	}
+
+	static long[] reorderToLong(final int[] array) {
+		final int n = array.length;
+		final long[] reordered = new long[n];
+		for (int i = 0; i < n; i++)
+			reordered[i] = array[n - i - 1];
+		return reordered;
+	}
+
+	static long[] reorderMultiplyToLong(final long[] in1, final int[] in2) {
+		final int n = in1.length;
+		final long[] reordered = new long[n];
+		for (int i = 0; i < n; i++)
+			reordered[i] = in1[n - i - 1] * in2[n - i - 1];
+		return reordered;
+	}
+
+	static class OpenDataSetCache {
+
+		private static final int MAX_OPEN_DATASETS = 48;
+
+		private final IHDF5Reader reader;
+
+		private final long fileId;
+
+		final long numericConversionXferPropertyListID;
+
+		private final Map<String, OpenDataSet> cache;
+
+		class OpenDataSet implements AutoCloseable {
+
+			private final AtomicInteger refcount;
+
+			final long dataSetId;
+
+			public OpenDataSet(final String pathName) {
+				refcount = new AtomicInteger(1);
+				dataSetId = H5Dopen(fileId, pathName, H5P_DEFAULT);
+			}
+
+			public void retain() {
+				if (refcount.getAndIncrement() <= 0)
+					throw new IllegalStateException();
+			}
+
+			@Override
+			public void close() {
+				if (refcount.decrementAndGet() == 0)
+					H5Dclose(dataSetId);
+			}
+		}
+
+		public OpenDataSetCache(final IHDF5Reader reader) {
+			this.reader = reader;
+
+			// TODO: Do see ch.systemsx.cisd.hdf5.HDF5.createFileAccessPropertyListId for version bounds checking
+			final long fileAccessPropertyListId = H5P_DEFAULT;
+
+			final IHDF5FileLevelReadOnlyHandler fileHandler = reader.file();
+			final boolean performNumericConversions = fileHandler.isPerformNumericConversions();
+			final File file = fileHandler.getFile();
+
+			// Make sure library is initialized. This can be called multiple times.
+			H5open();
+
+			// See ch.systemsx.cisd.hdf5.HDF5 constructor
+			// Make sure to close the numericConversionXferPropertyListID property list created below. See close()
+			if (performNumericConversions) {
+				numericConversionXferPropertyListID = HDFHelper.H5Pcreate_xfer_abort_overflow();
+			} else {
+				numericConversionXferPropertyListID = HDFHelper.H5Pcreate_xfer_abort();
+			}
+
+			// Make sure to close the fileID created below. See close()
+			fileId = H5Fopen(file.getAbsolutePath(), H5F_ACC_RDONLY, fileAccessPropertyListId);
+
+			cache = new LinkedHashMap<String, OpenDataSet>(MAX_OPEN_DATASETS, 0.75f, true) {
+
+				@Override
+				protected boolean removeEldestEntry(final Map.Entry<String, OpenDataSet> eldest) {
+					if (size() > MAX_OPEN_DATASETS) {
+						final OpenDataSet dataSet = eldest.getValue();
+						if (dataSet != null)
+							dataSet.close();
+						return true;
+					} else {
+						return false;
+					}
+				}
+			};
+		}
+
+		private boolean datasetExists(String pathName) {
+
+			if (pathName.equals(""))
+				pathName = "/";
+
+			return reader.exists(pathName) && reader.object().isDataSet(pathName);
+		}
+
+		public synchronized OpenDataSet get(final String pathName) {
+			OpenDataSet dataSet = cache.get(pathName);
+			if (dataSet == null && datasetExists(pathName)) {
+				dataSet = new OpenDataSet(pathName);
+				cache.put(pathName, dataSet);
+			}
+			if (dataSet != null)
+				dataSet.retain();
+			return dataSet;
+		}
+
+		public synchronized void remove(final String pathName) {
+			final OpenDataSet dataSet = cache.remove(pathName);
+			if (dataSet != null)
+				dataSet.close();
+		}
+
+		// close and remove all datasets in the cache
+		public synchronized void clear() {
+			cache.values().forEach(OpenDataSet::close);
+			cache.clear();
+		}
+
+		public synchronized void close() {
+			clear();
+			int status = H5Pclose(numericConversionXferPropertyListID);
+			if (status < 0) {
+				throw new RuntimeException("Error closing property list");
+			}
+			status = H5Fclose(fileId);
+			if (status < 0) {
+				throw new RuntimeException("Error closing file");
+			}
+		}
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Writer.java
@@ -50,6 +50,17 @@ import ch.systemsx.cisd.hdf5.HDF5Factory;
 import ch.systemsx.cisd.hdf5.HDF5FloatStorageFeatures;
 import ch.systemsx.cisd.hdf5.HDF5IntStorageFeatures;
 import ch.systemsx.cisd.hdf5.IHDF5Writer;
+import org.janelia.saalfeldlab.n5.hdf5.N5HDF5Util.OpenDataSetCache.OpenDataSet;
+
+import static hdf.hdf5lib.H5.H5Dget_space;
+import static hdf.hdf5lib.H5.H5Dwrite;
+import static hdf.hdf5lib.H5.H5Sclose;
+import static hdf.hdf5lib.H5.H5Screate_simple;
+import static hdf.hdf5lib.H5.H5Sselect_hyperslab;
+import static hdf.hdf5lib.HDF5Constants.H5P_DEFAULT;
+import static hdf.hdf5lib.HDF5Constants.H5S_SELECT_SET;
+import static org.janelia.saalfeldlab.n5.hdf5.N5HDF5Util.reorderMultiplyToLong;
+import static org.janelia.saalfeldlab.n5.hdf5.N5HDF5Util.reorderToLong;
 
 /**
  * Best effort {@link N5Writer} implementation for HDF5 files.
@@ -352,56 +363,17 @@ public class N5HDF5Writer extends N5HDF5Reader implements N5Writer {
 		if (pathName.equals(""))
 			pathName = "/";
 
-		final int[] hdf5DataBlockSize = dataBlock.getSize().clone();
-		reorder(hdf5DataBlockSize);
-		final int[] hdf5BlockSize = datasetAttributes.getBlockSize().clone();
-		reorder(hdf5BlockSize);
-		final long[] gridPosition = dataBlock.getGridPosition();
-		final long[] hdf5Offset = new long[gridPosition.length];
-		Arrays.setAll(hdf5Offset, i -> gridPosition[gridPosition.length - i - 1] * hdf5BlockSize[i]);
-		switch (datasetAttributes.getDataType()) {
-		case UINT8:
-			final MDByteArray uint8TargetCell = new MDByteArray((byte[])dataBlock.getData(), hdf5DataBlockSize);
-			writer.uint8().writeMDArrayBlockWithOffset(pathName, uint8TargetCell, hdf5Offset);
-			break;
-		case INT8:
-			final MDByteArray int8TargetCell = new MDByteArray((byte[])dataBlock.getData(), hdf5DataBlockSize);
-			writer.int8().writeMDArrayBlockWithOffset(pathName, int8TargetCell, hdf5Offset);
-			break;
-		case UINT16:
-			final MDShortArray uint16TargetCell = new MDShortArray((short[])dataBlock.getData(), hdf5DataBlockSize);
-			writer.uint16().writeMDArrayBlockWithOffset(pathName, uint16TargetCell, hdf5Offset);
-			break;
-		case INT16:
-			final MDShortArray int16TargetCell = new MDShortArray((short[])dataBlock.getData(), hdf5DataBlockSize);
-			writer.int16().writeMDArrayBlockWithOffset(pathName, int16TargetCell, hdf5Offset);
-			break;
-		case UINT32:
-			final MDIntArray uint32TargetCell = new MDIntArray((int[])dataBlock.getData(), hdf5DataBlockSize);
-			writer.uint32().writeMDArrayBlockWithOffset(pathName, uint32TargetCell, hdf5Offset);
-			break;
-		case INT32:
-			final MDIntArray int32TargetCell = new MDIntArray((int[])dataBlock.getData(), hdf5DataBlockSize);
-			writer.int32().writeMDArrayBlockWithOffset(pathName, int32TargetCell, hdf5Offset);
-			break;
-		case UINT64:
-			final MDLongArray uint64TargetCell = new MDLongArray((long[])dataBlock.getData(), hdf5DataBlockSize);
-			writer.uint64().writeMDArrayBlockWithOffset(pathName, uint64TargetCell, hdf5Offset);
-			break;
-		case INT64:
-			final MDLongArray int64TargetCell = new MDLongArray((long[])dataBlock.getData(), hdf5DataBlockSize);
-			writer.int64().writeMDArrayBlockWithOffset(pathName, int64TargetCell, hdf5Offset);
-			break;
-		case FLOAT32:
-			final MDFloatArray float32TargetCell = new MDFloatArray((float[])dataBlock.getData(), hdf5DataBlockSize);
-			writer.float32().writeMDArrayBlockWithOffset(pathName, float32TargetCell, hdf5Offset);
-			break;
-		case FLOAT64:
-			final MDDoubleArray float64TargetCell = new MDDoubleArray((double[])dataBlock.getData(), hdf5DataBlockSize);
-			writer.float64().writeMDArrayBlockWithOffset(pathName, float64TargetCell, hdf5Offset);
-			break;
-		default:
-			throw new UnsupportedOperationException(datasetAttributes.getDataType() + " datatype not currently supported.");
+		final long[] hdf5DataBlockSize = reorderToLong(dataBlock.getSize());
+		final long[] hdf5Offset = reorderMultiplyToLong(dataBlock.getGridPosition(), datasetAttributes.getBlockSize());
+
+		try (OpenDataSet dataset = openDataSetCache.get(pathName)) {
+			final long memorySpaceId = H5Screate_simple(hdf5DataBlockSize.length, hdf5DataBlockSize, null);
+			final long fileSpaceId = H5Dget_space(dataset.dataSetId);
+			H5Sselect_hyperslab(fileSpaceId, H5S_SELECT_SET, hdf5Offset, null, hdf5DataBlockSize, null);
+			final long memTypeId = N5HDF5Util.memTypeId(datasetAttributes.getDataType());
+			H5Dwrite(dataset.dataSetId, memTypeId, memorySpaceId, fileSpaceId, H5P_DEFAULT, dataBlock.getData());
+			H5Sclose(fileSpaceId);
+			H5Sclose(memorySpaceId);
 		}
 	}
 
@@ -414,73 +386,30 @@ public class N5HDF5Writer extends N5HDF5Reader implements N5Writer {
 			pathName = "/";
 
 		final DatasetAttributes datasetAttributes = getDatasetAttributes(pathName);
-
-		final long[] hdf5Dimensions = datasetAttributes.getDimensions().clone();
-		reorder(hdf5Dimensions);
-		final int[] hdf5BlockSize = datasetAttributes.getBlockSize().clone();
-		reorder(hdf5BlockSize);
-		final long[] hdf5GridPosition = gridPosition.clone();
-		reorder(hdf5GridPosition);
-		final int[] hdf5CroppedBlockSize = new int[hdf5BlockSize.length];
-		final long[] hdf5Offset = new long[hdf5GridPosition.length];
-		cropBlockSize(
-				hdf5GridPosition,
-				hdf5Dimensions,
-				hdf5BlockSize,
-				hdf5CroppedBlockSize,
-				hdf5Offset);
-
-		switch (datasetAttributes.getDataType()) {
+		final DataType dataType = datasetAttributes.getDataType();
+		switch (dataType) {
 			case UINT8:
-				final MDByteArray uint8TargetCell = new MDByteArray(hdf5CroppedBlockSize);
-				writer.uint8().writeMDArrayBlockWithOffset(pathName, uint8TargetCell, hdf5Offset);
-				break;
 			case INT8:
-				final MDByteArray int8TargetCell = new MDByteArray(hdf5CroppedBlockSize);
-				writer.int8().writeMDArrayBlockWithOffset(pathName, int8TargetCell, hdf5Offset);
-				break;
 			case UINT16:
-				final MDShortArray uint16TargetCell = new MDShortArray(hdf5CroppedBlockSize);
-				writer.uint16().writeMDArrayBlockWithOffset(pathName, uint16TargetCell, hdf5Offset);
-				break;
 			case INT16:
-				final MDShortArray int16TargetCell = new MDShortArray(hdf5CroppedBlockSize);
-				writer.int16().writeMDArrayBlockWithOffset(pathName, int16TargetCell, hdf5Offset);
-				break;
 			case UINT32:
-				final MDIntArray uint32TargetCell = new MDIntArray(hdf5CroppedBlockSize);
-				writer.uint32().writeMDArrayBlockWithOffset(pathName, uint32TargetCell, hdf5Offset);
-				break;
 			case INT32:
-				final MDIntArray int32TargetCell = new MDIntArray(hdf5CroppedBlockSize);
-				writer.int32().writeMDArrayBlockWithOffset(pathName, int32TargetCell, hdf5Offset);
-				break;
 			case UINT64:
-				final MDLongArray uint64TargetCell = new MDLongArray(hdf5CroppedBlockSize);
-				writer.uint64().writeMDArrayBlockWithOffset(pathName, uint64TargetCell, hdf5Offset);
-				break;
 			case INT64:
-				final MDLongArray int64TargetCell = new MDLongArray(hdf5CroppedBlockSize);
-				writer.int64().writeMDArrayBlockWithOffset(pathName, int64TargetCell, hdf5Offset);
-				break;
 			case FLOAT32:
-				final MDFloatArray float32TargetCell = new MDFloatArray(hdf5CroppedBlockSize);
-				writer.float32().writeMDArrayBlockWithOffset(pathName, float32TargetCell, hdf5Offset);
-				break;
 			case FLOAT64:
-				final MDDoubleArray float64TargetCell = new MDDoubleArray(hdf5CroppedBlockSize);
-				writer.float64().writeMDArrayBlockWithOffset(pathName, float64TargetCell, hdf5Offset);
-				break;
+				final DataBlock<?> empty = dataType.createDataBlock(datasetAttributes.getBlockSize(), gridPosition);
+				writeBlock(pathName, datasetAttributes, empty);
+				return true;
 			default:
 				return false;
 		}
-
-		return true;
 	}
 
 	@Override
 	public boolean remove() {
 
+		openDataSetCache.close();
 		final File file = writer.file().getFile();
 		writer.close();
 		return file.delete();
@@ -492,6 +421,7 @@ public class N5HDF5Writer extends N5HDF5Reader implements N5Writer {
 		if (pathName.equals(""))
 			pathName = "/";
 
+		openDataSetCache.remove(pathName);
 		writer.delete(pathName);
 		return !writer.exists(pathName);
 	}


### PR DESCRIPTION
When reading/writing a block through jhdf5, the dataset is opened/closed every time.

Instead, we maintain a LRU cache of open datasets, and use lower-level functions to read/write data. This improves performance when accessing many blocks of the same dataset consecutively.

Using the lower-level functions also eliminates boilerplate for switching over DataType.