### PR TITLE
fix: improve datasetExists performance

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Util.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/hdf5/N5HDF5Util.java
@@ -3,6 +3,10 @@ package org.janelia.saalfeldlab.n5.hdf5;
 import ch.systemsx.cisd.hdf5.IHDF5FileLevelReadOnlyHandler;
 import ch.systemsx.cisd.hdf5.IHDF5Reader;
 import ch.systemsx.cisd.hdf5.hdf5lib.HDFHelper;
+import hdf.hdf5lib.H5;
+import hdf.hdf5lib.HDF5Constants;
+import hdf.hdf5lib.exceptions.HDF5LibraryException;
+import hdf.hdf5lib.structs.H5O_info_t;
 import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -16,6 +20,7 @@ import static hdf.hdf5lib.H5.H5Fopen;
 import static hdf.hdf5lib.H5.H5Pclose;
 import static hdf.hdf5lib.H5.H5open;
 import static hdf.hdf5lib.HDF5Constants.H5F_ACC_RDONLY;
+import static hdf.hdf5lib.HDF5Constants.H5O_TYPE_DATASET;
 import static hdf.hdf5lib.HDF5Constants.H5P_DEFAULT;
 import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_DOUBLE;
 import static hdf.hdf5lib.HDF5Constants.H5T_NATIVE_FLOAT;
@@ -153,10 +158,15 @@ final class N5HDF5Util {
 
 		private boolean datasetExists(String pathName) {
 
-			if (pathName.equals(""))
-				pathName = "/";
+			if ("".equals(pathName) || "/".equals(pathName))
+				return false;
 
-			return reader.exists(pathName) && reader.object().isDataSet(pathName);
+			try {
+				final H5O_info_t info = H5.H5Oget_info_by_name(fileId, pathName, HDF5Constants.H5O_INFO_BASIC, HDF5Constants.H5P_DEFAULT);
+				return info.type == H5O_TYPE_DATASET;
+			} catch (HDF5LibraryException e) {
+				return false;
+			}
 		}
 
 		public synchronized OpenDataSet get(final String pathName) {


### PR DESCRIPTION
See https://github.com/bigdataviewer/bigdataviewer-core/issues/165

(This also affects reader.object().isDataSet() which was used previously here, because that internally uses the slow H5Oget_info_by_name variant.)